### PR TITLE
Inclusion of the `mod_icon.jpg` pixel size.

### DIFF
--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -170,7 +170,7 @@ The icon is an image file which identifies how your mod will look in-game. If yo
 
 ![](/images/mod_ico.png)
 
-You should place a copy of your desired image into `RP/dlc_data`. The image needs to be named `icon.jpg`. Do the same for `icon_alt` and `reward`.
+You should place a copy of your desired image into `RP/dlc_data`. The image needs to be named `icon.jpg`. Do the same for `icon_alt` and `reward`. Note that the `mod_icon.jpg` should be a 324 by 325 image for best results. Otherwise, the image will stretch to fit the dimensions, so be careful!
 
 ## Language Files
 


### PR DESCRIPTION
I added a segment to the part of adding an icon. It specifies the optimal dimensions of an image, and if it doesn't fill the optimal dimensions, it will stretch the image.